### PR TITLE
edit-user

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,7 +1,7 @@
 .main-chat
   .member-list
     .left-list
-      = @group.name 
+      = @group.name
       .left-list__members
         Member: 
         %ul

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,7 +1,7 @@
 .message{data: {message: {id: message.id}}}
   .over
     .over__user-name
-       
+     
     .over__date
 
   .under

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -6,8 +6,6 @@
       %ul.top-items__function
         = link_to new_group_path do
           = icon('fa', 'edit',class: 'mark')
-        = link_to edit_user_path(current_user) do
-          = icon('fa', 'cog',class: 'mark')
         = link_to root_path do
           = icon('fa', 'home',class: 'mark')
   .group-list

--- a/app/views/stocks/_links.html.haml
+++ b/app/views/stocks/_links.html.haml
@@ -19,5 +19,7 @@
         -# %li.menu__top__lists__links
         -#   = link_to "チャット",groups_path,class: "menu__top__lists__links__btn"
         %li.menu__top__lists__links
+          = link_to "メアド編集",edit_user_path(current_user) ,class: "menu__top__lists__links__btn"
+        %li.menu__top__lists__links
           =link_to "ログアウト", users_sign_out_path,class: "menu__top__lists__links__btn",id: "logout"
   

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -9,13 +9,6 @@
       = form_for(current_user) do |f|
         .field
           .field-label
-            = f.label :store
-          .field-label
-            = f.label :name
-          .field-input
-            = f.text_field :name, autofocus: true
-        .field
-          .field-label
             = f.label :email
           .field-input
             = f.email_field :email

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,8 +57,4 @@ ActiveRecord::Schema.define(version: 2020_11_14_090614) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "group_users", "groups"
-  add_foreign_key "group_users", "users"
-  add_foreign_key "messages", "groups"
-  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
[WHAT]
・ユーザー編集のボタンの位置をトップページに移動させ、編集内容をメアドのみにしました

[WHY]
・食品を扱うお店で使うことを想定している以上、店名やユーザー名の変更の必要を感じなかったため。