### PR TITLE
Capistrano3

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -41,3 +41,6 @@ install_plugin Capistrano::SCM::Git
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
+
+Rake::Task[:production].invoke
+invoke :production


### PR DESCRIPTION
[WHAT]
Capistrano3 でデフォルトの環境を指定しました

[WHY]
ステージを省略しても config/deploy/production.rb の内容が読み込まれ実行されるようにするため