### PR TITLE
unicorn ver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 group :productiondo, :staging do
-  gem 'unicorn'
+  gem 'unicorn', '5.4.1'
 end
 
 gem 'haml-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,7 +334,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    unicorn (5.7.0)
+    unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     warden (1.2.9)
@@ -392,7 +392,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
-  unicorn
+  unicorn (= 5.4.1)
   web-console (>= 3.3.0)
 
 RUBY VERSION


### PR DESCRIPTION
[WHAT]
unicornのバージョンを固定しました。

[WHY]
unicornのバージョンアップによる仕様変更に対応していないために起きたと思われるエラーが発生したため。