### PR TITLE
password

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -26,5 +26,5 @@ production:
   pool: 5
   database: stockapp
   username: root
-  password:
+  password: EfGdlc&yf6rJ
   socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
[WHAT]
config/database.ymlのパスワードを入力しました

[WHY]
初期パスワードの記載をしなかったせいでUnicornの起動ができていなかったため。