### PR TITLE
change-password

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -26,5 +26,5 @@ production:
   pool: 5
   database: stockapp
   username: root
-  password: EfGdlc&yf6rJ
+  password: EfGdlc&yf6rJ123
   socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
[WHAT]
mysqlのパスワードを変更し、それをdatabase.ymlに反映させました。

[WHY]
Mysqlのバージョンの都合上、初期パスワードの設定が必要だったため安全性の高いパスワードに変更しました。