### PR TITLE
comment-out

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,8 +23,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  # config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
+  config.assets.js_compressor = :uglifier
+  config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
[WHAT]
config/environments/production.rbの一部箇所のコメントアウトを解除しました。

[WHY]
本番環境でSCSSを適応させるため。