### PR TITLE
set_production

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,7 @@
 server '3.114.40.165', user: 'ec2-user', roles: %w{app db web} 
+
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
 # server-based syntax
 # ======================
 # Defines a single server with a list of roles and multiple properties.


### PR DESCRIPTION
[WHAT]
capistranoのファイルを追記しました。

[WHY]
capistranoでunicornを起動させる用の記述がなかったため。