### PR TITLE
WorkFlow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,19 @@
 version: 2.1
-orbs:
-  ruby: circleci/ruby@0.1.2 
-
 jobs:
-  build:
-    docker:
-      - image: circleci/ruby:2.6.3-stretch-node
-    executor: ruby/default
+  deploy:
+    machine:
+      enabled: true
     steps:
-      - checkout
-      - run:
-          name: Which bundler?
-          command: bundle -v
-      - ruby/bundle-install
+      - add_ssh_keys:
+          fingerprints:
+            - "xxxxxxxxxxxxxxxxxxxxxxxxxxx" #上記メモったハッシュを指定
+      - run: ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "/var/www/stockapp/deploy-me.sh"
+ 
+workflows:
+  version: 2
+  deploy:
+    jobs:
+      - deploy:
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
[WHAT]
.circleci/config.ymlの記述を修正しました。

[WHY]
workflows で filters の記述によって、masterブランチ以外ではデプロイのJobが実行されないようにするため。